### PR TITLE
Added full support for fetching and tweeting of longer tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Once you have a model, the primary use is to produce statements and related resp
 
 ``` ruby
 > model = Ebooks::Model.load("model/0xabad1dea.model")
-> model.make_statement(140)
+> model.make_statement(280)
 => "My Terrible Netbook may be the kind of person who buys Starbucks, but this Rackspace vuln is pretty straight up a backdoor"
 > model.make_response("The NSA is coming!", 130)
 => "Hey - someone who claims to be an NSA conspiracy"

--- a/lib/twitter_ebooks/archive.rb
+++ b/lib/twitter_ebooks/archive.rb
@@ -82,7 +82,8 @@ module Ebooks
       opts = {
         count: 200,
         #include_rts: false,
-        trim_user: true
+        trim_user: true,
+        tweet_mode: 'extended'
       }
 
       opts[:since_id] = @tweets[0][:id] unless @tweets.nil?

--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -95,7 +95,7 @@ module Ebooks
       @reply_mentions = ([ev.user.screen_name] + reply_mentions).uniq
 
       @reply_prefix = @reply_mentions.map { |m| '@'+m }.join(' ') + ' '
-      @limit = 140 - @reply_prefix.length
+      @limit = 280 - @reply_prefix.length
 
       mless = ev.text
       begin

--- a/lib/twitter_ebooks/model.rb
+++ b/lib/twitter_ebooks/model.rb
@@ -142,7 +142,7 @@ module Ebooks
       if path.split('.')[-1] == "json"
         log "Reading json corpus from #{path}"
         lines = JSON.parse(content).map do |tweet|
-          tweet['text']
+            tweet['text'] || tweet['full_text']
         end
       elsif path.split('.')[-1] == "csv"
         log "Reading CSV corpus from #{path}"
@@ -205,7 +205,7 @@ module Ebooks
         if path.split('.')[-1] == "json"
           log "Reading json corpus from #{path}"
           l = JSON.parse(content).map do |tweet|
-            tweet['text']
+            tweet['text'] || tweet['full_text']
           end
           lines.concat(l)
         elsif path.split('.')[-1] == "csv"
@@ -246,7 +246,7 @@ module Ebooks
     # @param generator [SuffixGenerator, nil]
     # @param retry_limit [Integer] how many times to retry on invalid tweet
     # @return [String]
-    def make_statement(limit=140, generator=nil, retry_limit=10)
+    def make_statement(limit=280, generator=nil, retry_limit=10)
       responding = !generator.nil?
       generator ||= SuffixGenerator.build(@sentences)
 
@@ -316,7 +316,7 @@ module Ebooks
     # @param limit [Integer] characters available for response
     # @param sentences [Array<Array<Integer>>]
     # @return [String]
-    def make_response(input, limit=140, sentences=@mentions)
+    def make_response(input, limit=280, sentences=@mentions)
       # Prefer mentions
       relevant, slightly_relevant = find_relevant(sentences, input)
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -10,13 +10,13 @@ describe Ebooks::Model do
 
     it "generates a tweet" do
       s = @model.make_statement
-      expect(s.length).to be <= 140
+      expect(s.length).to be <= 280
       puts s
     end
 
     it "generates an appropriate response" do
       s = @model.make_response("hi")
-      expect(s.length).to be <= 140
+      expect(s.length).to be <= 280
       expect(s.downcase).to include("hi")
       puts s
     end


### PR DESCRIPTION
Cherry-picked from https://github.com/Foxdear/twitter_ebooks/commit/04c58acb1f6098510355f953c6e496813da00f09 ; fixes #7 

>With the update to Twitter that allows you to make 280 character tweets,
>you have to specify "tweet_mode: extended" when getting JSON tweets,
>otherwise you get truncated 140 character versions. This also changes
>the key in the retrieved data to be "full_text" instead of just "text".
>I added a check so that if "full_text" is present to define that as the
>tweet text, and if not to use "text" (for backwards compatibility with
>existing JSON archives).
>Also updated the hard limits in places to be 280 instead of 140.